### PR TITLE
fixed GD with JPEG support.

### DIFF
--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -44,11 +44,11 @@ RUN docker-php-ext-install pdo_pgsql
 #####################################
 
 # Install the PHP gd library
-RUN docker-php-ext-install gd && \
-    docker-php-ext-configure gd \
+RUN docker-php-ext-configure gd \
         --enable-gd-native-ttf \
         --with-jpeg-dir=/usr/lib \
-        --with-freetype-dir=/usr/include/freetype2
+        --with-freetype-dir=/usr/include/freetype2 && \
+    docker-php-ext-install gd
 
 #####################################
 # Memcached:


### PR DESCRIPTION
OK, I fixed the problem #1 now. 

It look like we must run `docker-php-ext-configure gd` first, and then `docker-php-ext-install gd`.

It's a order problem....