### PR TITLE
fix Dockerfile-56

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -35,7 +35,7 @@ RUN docker-php-ext-install mcrypt
 
 # Install the PHP pdo_mysql extention
 RUN docker-php-ext-install mysqli \
-    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install pdo_mysql
 # Install the PHP pdo_pgsql extention
 RUN docker-php-ext-install pdo_pgsql
 


### PR DESCRIPTION
fix for: error: /usr/src/php/ext/RUN does not exist