### PR TITLE
Remove runtime option removed in PHP 7.2

### DIFF
--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -39,7 +39,6 @@ RUN apt-get update \
   && docker-php-ext-install pdo_pgsql \
   # Install the PHP gd library
   && docker-php-ext-configure gd \
-    --enable-gd-native-ttf \
     --with-jpeg-dir=/usr/lib \
     --with-freetype-dir=/usr/include/freetype2 && \
     docker-php-ext-install gd


### PR DESCRIPTION
Remove **--enable-gd-native-ttf**  from gd configuration.

[http://php.net/manual/en/image.installation.php](http://php.net/manual/en/image.installation.php)

> To enable support for native TrueType string function add --enable-gd-native-ttf . (Effectless as of PHP 5.5.0; removed as of PHP 7.2.0.) 