### PR TITLE
Add libonig-dev package

### DIFF
--- a/Dockerfile-74
+++ b/Dockerfile-74
@@ -31,6 +31,7 @@ RUN apt-get update && \
     libfreetype6-dev \
     libssl-dev \
     libmcrypt-dev \
+    libonig-dev \
   && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Oniguruma is not packaged in php 7.4, so if you try to install mbstring, you will get an error like this:

```
# docker-php-ext-install mbstring
...
checking for oniguruma... no
configure: error: Package requirements (oniguruma) were not met:

No package 'oniguruma' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables ONIG_CFLAGS
and ONIG_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

So, install oniguruma library.