### PR TITLE
Push git tag to docker hub

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,8 +3,12 @@ name: Docker Image CI
 on:
   push:
     branches: master
+    tags: '**'
   schedule:
   - cron: 0 0 * * 6
+
+env:
+  TAG_PREFIX: $([ ${GITHUB_REF#refs/*/} == "master" ] && echo "latest" || echo ${GITHUB_REF#refs/*/})
 
 jobs:
   build:
@@ -19,7 +23,7 @@ jobs:
         PHP_VERSION: ${{ matrix.php_version }}
       run: |
         export TAG_VERSION=${PHP_VERSION:0:1}.${PHP_VERSION:1:1}
-        docker build . --file Dockerfile-${{ matrix.php_version }} --tag laradock/php-fpm:latest-${TAG_VERSION}      
+        docker build . --file Dockerfile-${{ matrix.php_version }} --tag laradock/php-fpm:${{ env.TAG_PREFIX }}-${TAG_VERSION}      
         docker image ls
 
     - name: Push image to Docker hub
@@ -29,5 +33,5 @@ jobs:
       run: |
         export TAG_VERSION=${PHP_VERSION:0:1}.${PHP_VERSION:1:1}
         echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USER }} --password-stdin
-        docker push laradock/php-fpm:latest-${TAG_VERSION}
+        docker push laradock/php-fpm:${{ env.TAG_PREFIX }}-${TAG_VERSION}
         docker logout


### PR DESCRIPTION
When push a git tag to GitHub, it will trigger the build, then push a new tag to docker hub.

A working example:
https://github.com/miaoxing/dockerfiles/runs/1662519271?check_suite_focus=true

And the result
https://hub.docker.com/r/miaoxing/php-fpm/tags?page=1&ordering=last_updated